### PR TITLE
Fixed parsing of urls to ignore dots in path parameters

### DIFF
--- a/src/clout/core.clj
+++ b/src/clout/core.clj
@@ -121,7 +121,7 @@
           word    #":([\p{L}_][\p{L}_0-9-]*)"
           literal #"(:[^\p{L}_*]|[^:*])+"
           word-group #(keyword (.group % 1))
-          word-regex #(regexs (word-group %) "[^/.,;?]+")]
+          word-regex #(regexs (word-group %) "[^/,;?]+")]
       (CompiledRoute.
         (re-pattern
           (apply str
@@ -140,3 +140,4 @@
   Route
   (route-matches [route request]
     (route-matches (route-compile route) request)))
+


### PR DESCRIPTION
Since the rfc states that dots are allowed in path parameters i fixed it in hopes to get this into ring.
