### PR TITLE
Allowing semi-colon and commas in path portions of requests?

### DIFF
--- a/src/clout/core.clj
+++ b/src/clout/core.clj
@@ -125,7 +125,7 @@
           word    #":([\p{L}_][\p{L}_0-9-]*)"
           literal #"(:[^\p{L}_*]|[^:*])+"
           word-group #(keyword (.group ^Matcher % 1))
-          word-regex #(regexs (word-group %) "[^/,;?]+")]
+          word-regex #(regexs (word-group %) "[^/?]+")]
       (CompiledRoute.
         (re-pattern
           (apply str


### PR DESCRIPTION
Hi,

Would you be open to allowing the semi-colon and comma characters in paths?

I believe this is ok from a standards perspective:

http://tools.ietf.org/html/rfc3986#section-3

and is a one-line change in core.clj (line 128)

word-regex #(regexs (word-group %) "[^/?]+")]

I ran against the existing test suite and it looks like all tests pass.

This would allow for requests like:

put "/resources/1;2;3/k1/v1

(PUT "/resources/:ids/:k/:v" [ids k v]

to match and destructure successfully - they currently do not.

Thanks - if you need me to do something in the tests or come up with documentation, I can try to add that as well, just not sure what you would prefer.  BTW, thanks much for the awesome web-app tools.
