### PR TITLE
Add original `path` to CompiledRoute record.

### DIFF
--- a/src/clout/core.clj
+++ b/src/clout/core.clj
@@ -73,7 +73,7 @@
     "If the route matches the supplied request, the matched keywords are
     returned as a map. Otherwise, nil is returned."))
 
-(defrecord CompiledRoute [re keys absolute?]
+(defrecord CompiledRoute [path re keys absolute?]
   Route
   (route-matches [route request]
     (let [path-info (if absolute?
@@ -126,7 +126,7 @@
           literal #"(:[^\p{L}_*]|[^:*])+"
           word-group #(keyword (.group ^Matcher % 1))
           word-regex #(regexs (word-group %) "[^/,;?]+")]
-      (CompiledRoute.
+      (CompiledRoute. path
         (re-pattern
           (apply str
             (lex path


### PR DESCRIPTION
This allows us to query a `CompiledRoute` for the original path it was
constructed from.

The background to this is that I also have the need for the following feature:
https://github.com/weavejester/compojure/issues/82

Discussion in other pull request:
https://github.com/weavejester/compojure/pull/93
