### PR TITLE
Fix README non-matching example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ anything.
 If a route does not match, nil is returned:
 
 ```clj
-user=> (route-matches "/products" "/articles")
+user=> (route-matches "/products" (request :get "/articles"))
 nil
 ```
 


### PR DESCRIPTION
The example of non-matching returning nil passes in a
string instead of a request, and thus if run in real life
fails with a `NullPointerException`.
