### PR TITLE
allow capturing groups which match nil

### DIFF
--- a/src/clout/core.clj
+++ b/src/clout/core.clj
@@ -21,8 +21,8 @@
   "More consistant re-groups that always returns a vector of groups, even if
   there is only one group."
   [^Matcher matcher]
-  (for [i (range (.groupCount matcher))]
-    (.group matcher (int (inc i)))))
+  (remove nil? (for [i (range (.groupCount matcher))]
+                 (.group matcher (int (inc i)))))
 
 ;; Route matching
 


### PR DESCRIPTION
Routes which match "foo", "foo/bar" "foo/bar/baz" etc need
a regexp like `#"([a-z]+/)*[a-z]+"`.
This regexp fails for "foo" since re-groups\* returns (nil)
(for the 1st capturing group which does not match).
This causes an exception to be thrown for route "foo".
