### PR TITLE
Add no-slurp hint for Instaparse

### DIFF
--- a/src/clout/core.clj
+++ b/src/clout/core.clj
@@ -65,7 +65,8 @@
 
     param    = key pattern?
     key      = <':'> #'([\\p{L}_][\\p{L}_0-9-]*)'
-    pattern  = '{' (#'(?:[^{}\\\\]|\\\\.)+' | pattern)* '}'"))
+    pattern  = '{' (#'(?:[^{}\\\\]|\\\\.)+' | pattern)* '}'"
+   :no-slurp true))
 
 (defn- parse [parser text]
   (let [result (insta/parse parser text)]


### PR DESCRIPTION
It is failing on platforms with no read access (like google appengine). See: Engelberg/instaparse#76
