### PR TITLE
Update Instaparse dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,4 +10,4 @@
          :dependencies [[ring/ring-mock "0.2.0"]
                         [criterium "0.4.2"]]}
    :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-   :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha6"]]}})
+   :1.7 {:dependencies [[org.clojure/clojure "1.7.0-beta2"]]}})

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [instaparse "1.3.6" :exclusions [org.clojure/clojure]]]
+                 [instaparse "1.4.0" :exclusions [org.clojure/clojure]]]
   :profiles
   {:dev {:jvm-opts ^:replace []
          :dependencies [[ring/ring-mock "0.2.0"]


### PR DESCRIPTION
Instaparse 1.3.6 throws a weird Exception on Clojure 1.7.0 beta 2. The problem is fixed in Instaparse 1.4.0. ([gist writeup][1])

**Note**: [Compojure's clout dependency][2] will need to be updated accordingly.

[1]: https://gist.github.com/yurrriq/4190ca1f404a5745e214
[2]: https://github.com/weavejester/compojure/blob/694225dc415f65a2a9bcc0316e411c611402db6a/project.clj#L8